### PR TITLE
Fix module not found error when starting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "husky": "^7.0.4",
         "mocha": "^9.2.0",
         "prettier": "^2.5.1",
+        "resolve-tspaths": "^0.2.4",
         "sinon": "^13.0.1",
         "ts-node": "^10.4.0",
         "tsconfig-paths": "^3.14.1",
@@ -1433,6 +1434,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/compressible": {
@@ -3139,6 +3149,12 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -4109,6 +4125,21 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-tspaths": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/resolve-tspaths/-/resolve-tspaths-0.2.4.tgz",
+      "integrity": "sha512-ckZyIp4XlJ62bGoUkilXUXxl9Mcrl4+o3/n1d9RLZ5tpswh92G9VqrfdyI5liWosUZRwF3gHin8ieEkr/+cEXg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "commander": "9.0.0",
+        "fast-glob": "3.2.11",
+        "jsonc-parser": "3.0.0"
+      },
+      "bin": {
+        "resolve-tspaths": "dist/main.js"
       }
     },
     "node_modules/retry": {
@@ -6042,6 +6073,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+      "dev": true
+    },
     "compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -7311,6 +7348,12 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "jsonwebtoken": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
@@ -8060,6 +8103,18 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-tspaths": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/resolve-tspaths/-/resolve-tspaths-0.2.4.tgz",
+      "integrity": "sha512-ckZyIp4XlJ62bGoUkilXUXxl9Mcrl4+o3/n1d9RLZ5tpswh92G9VqrfdyI5liWosUZRwF3gHin8ieEkr/+cEXg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "4.1.1",
+        "commander": "9.0.0",
+        "fast-glob": "3.2.11",
+        "jsonc-parser": "3.0.0"
+      }
     },
     "retry": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint:code": "eslint .",
     "lint:fix": "eslint --fix .",
     "format": "prettier -w .",
-    "build": "tsc -p .",
+    "build": "tsc && resolve-tspaths",
     "clean": "rm -rf ./build/*",
     "start": "node ./build/index.js",
     "prepare": "husky install"
@@ -46,6 +46,7 @@
     "husky": "^7.0.4",
     "mocha": "^9.2.0",
     "prettier": "^2.5.1",
+    "resolve-tspaths": "^0.2.4",
     "sinon": "^13.0.1",
     "ts-node": "^10.4.0",
     "tsconfig-paths": "^3.14.1",


### PR DESCRIPTION
introduced in 81eeecd1b47e00d4579367ef81c92da152e778bb, we added the
typescript path alias, but tsc doesn't resolve the alias automatically
in compilation. I added resolve-tspaths that updates the paths in
generated files.